### PR TITLE
Add fixture with minimum fields to save in aspace

### DIFF
--- a/fixtures/single_level_required/invalid/minimum_to_save.json
+++ b/fixtures/single_level_required/invalid/minimum_to_save.json
@@ -1,0 +1,117 @@
+{
+    "lock_version": 0,
+    "title": "Single level minimum resource",
+    "publish": false,
+    "restrictions": false,
+    "created_by": "bgordon",
+    "last_modified_by": "bgordon",
+    "create_time": "2022-04-11T00:42:52Z",
+    "system_mtime": "2022-04-11T00:42:52Z",
+    "user_mtime": "2022-04-11T00:42:52Z",
+    "suppressed": false,
+    "is_slug_auto": false,
+    "id_0": "12345",
+    "level": "collection",
+    "finding_aid_language": "eng",
+    "finding_aid_script": "Latn",
+    "jsonmodel_type": "resource",
+    "external_ids": [
+
+    ],
+    "subjects": [
+
+    ],
+    "linked_events": [
+
+    ],
+    "extents": [
+        {
+            "lock_version": 0,
+            "number": "3",
+            "created_by": "bgordon",
+            "last_modified_by": "bgordon",
+            "create_time": "2022-04-11T00:42:52Z",
+            "system_mtime": "2022-04-11T00:42:52Z",
+            "user_mtime": "2022-04-11T00:42:52Z",
+            "portion": "whole",
+            "extent_type": "document box(es)",
+            "jsonmodel_type": "extent"
+        }
+    ],
+    "lang_materials": [
+        {
+            "lock_version": 0,
+            "created_by": "bgordon",
+            "last_modified_by": "bgordon",
+            "create_time": "2022-04-11T00:42:52Z",
+            "system_mtime": "2022-04-11T00:42:52Z",
+            "user_mtime": "2022-04-11T00:42:52Z",
+            "jsonmodel_type": "lang_material",
+            "notes": [
+
+            ],
+            "language_and_script": {
+                "lock_version": 0,
+                "created_by": "bgordon",
+                "last_modified_by": "bgordon",
+                "create_time": "2022-04-11T00:42:52Z",
+                "system_mtime": "2022-04-11T00:42:52Z",
+                "user_mtime": "2022-04-11T00:42:52Z",
+                "language": "eng",
+                "jsonmodel_type": "language_and_script"
+            }
+        }
+    ],
+    "dates": [
+        {
+            "lock_version": 0,
+            "begin": "1990",
+            "end": "1995",
+            "created_by": "bgordon",
+            "last_modified_by": "bgordon",
+            "create_time": "2022-04-11T00:42:52Z",
+            "system_mtime": "2022-04-11T00:42:52Z",
+            "user_mtime": "2022-04-11T00:42:52Z",
+            "date_type": "inclusive",
+            "label": "creation",
+            "jsonmodel_type": "date"
+        }
+    ],
+    "external_documents": [
+
+    ],
+    "rights_statements": [
+
+    ],
+    "linked_agents": [
+
+    ],
+    "revision_statements": [
+
+    ],
+    "instances": [
+
+    ],
+    "deaccessions": [
+
+    ],
+    "related_accessions": [
+
+    ],
+    "classifications": [
+
+    ],
+    "notes": [
+
+    ],
+    "metadata_rights_declarations": [
+
+    ],
+    "uri": "/repositories/2/resources/13287",
+    "repository": {
+        "ref": "/repositories/2"
+    },
+    "tree": {
+        "ref": "/repositories/2/resources/13287/tree"
+    }
+}


### PR DESCRIPTION
Adds a fixture with the minimum fields required to save a [resource in ArchivesSpace](https://github.com/archivesspace/archivesspace/blob/master/common/schemas/resource.rb).

Between this and the existing invalid fixtures to test the two different schemas, I'd say we have pretty good coverage! We may want to add or remove additional fixtures once we're testing specific validation messages.

Fixes #56 