### PR TITLE
Allow script to be run from command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ log.txt
 *__pycache__
 .coverage
 .tox
+build
+*.egg-info
+.pytest_cache

--- a/dacsspace/command_line.py
+++ b/dacsspace/command_line.py
@@ -1,10 +1,16 @@
 import argparse
 
-from dacsspace.dacsspace import DACSspace
+from .dacsspace import DACSspace
 
-if __name__ == '__main__':
+
+def main():
+    """Command line entrypoint for DACSspace. Parses arguments received from stdin."""
     parser = argparse.ArgumentParser(
-        description="Fetches data from AS, validates and reports results")
+        description="Fetches data from ArchivesSpace, validates and reports results")
+    parser.add_argument(
+        'csv_filepath',
+        help='Filepath for results report (CSV format)',
+        type=str)
     parser.add_argument(
         '--published_only',
         help='Fetches only published records from AS',
@@ -17,14 +23,16 @@ if __name__ == '__main__':
     group.add_argument(
         '--schema_identifier',
         help='Choose schema_identifier or schema_filepath. schema_identifier default is single_level_required.json',
-        type=str, default='single_level_required.json')
+        type=str,
+        default='single_level_required.json')
     group.add_argument(
         '--schema_filepath',
         help='Choose schema_identifier or schema_filepath. Schema_filepath default is None, only one of schema_identifier',
-        type=str, default=None)
+        type=str,
+        default=None)
     args = parser.parse_args()
 
-    DACSspace().run(
+    DACSspace(args.csv_filepath).run(
         args.published_only,
         args.invalid_only,
         args.schema_identifier,

--- a/dacsspace/dacsspace.py
+++ b/dacsspace/dacsspace.py
@@ -23,5 +23,5 @@ class DACSspace:
         validator = Validator(schema_identifier, schema_filepath)
         reporter = CSVReporter(self.csv_filepath)
         data = client.get_resources(published_only)
-        results = [validator.validate(obj) for obj in data]
+        results = [validator.validate_data(obj) for obj in data]
         reporter.write_report(results, invalid_only)

--- a/dacsspace/dacsspace.py
+++ b/dacsspace/dacsspace.py
@@ -15,15 +15,13 @@ class DACSspace:
         if re.search(r'[*?:"<>|]', csv_filepath):
             raise ValueError(
                 'File name cannot contain the following characters: * ? : " < > | ')
+        self.csv_filepath = csv_filepath
 
     def run(self, published_only, invalid_only,
             schema_identifier, schema_filepath):
         client = ArchivesSpaceClient()
         validator = Validator(schema_identifier, schema_filepath)
-        reporter = CSVReporter()
+        reporter = CSVReporter(self.csv_filepath)
         data = client.get_resources(published_only)
-        results = []
-        for obj in data:
-            result = validator.validate(obj)
-            results.append(result)
+        results = [validator.validate(obj) for obj in data]
         reporter.write_report(results, invalid_only)

--- a/dacsspace/local_settings.example
+++ b/dacsspace/local_settings.example
@@ -3,7 +3,3 @@ baseurl: https://sandbox.archivesspace.org/api/
 repository: 101
 user: admin
 password: admin
-
-[Destinations]
-directory: #Directory where you would like to save the csv file
-filename: dacs_singlelevel_report.csv

--- a/dacsspace/reporter.py
+++ b/dacsspace/reporter.py
@@ -21,6 +21,7 @@ class CSVReporter:
             raise ValueError("Filemode must allow write options.")
         with open(self.filename, self.filemode) as f:
             fieldnames = [
+                "uri",
                 "valid",
                 "explanation"]
             writer = csv.DictWriter(

--- a/dacsspace/validator.py
+++ b/dacsspace/validator.py
@@ -28,13 +28,16 @@ class Validator:
             data (dict): An ArchivesSpace object to be validated.
 
         Returns:
-           result (dict): The result of the validation. An dictionary with a boolean
-           indication of the validation result and, if necessary, an explanation
-           of any validation errors. { "valid": False, "explanation": "You are missing the following fields..." }
+           result (dict): The result of the validation. An dictionary with the
+           object's URI, a boolean indication of the validation result and, if
+           necessary, an explanation of any validation errors.
+
+           { "uri": "/repositories/2/resources/1234", "valid": False, "explanation": "You are missing the following fields..." }
         """
         validator = self.validator(self.schema)
         errors_found = [error.message for error in validator.iter_errors(data)]
         if len(errors_found):
-            return {"valid": False, "explanation": "\n".join(errors_found)}
+            return {"uri": data["uri"], "valid": False,
+                    "explanation": "\n".join(errors_found)}
         else:
-            return {"valid": True}
+            return {"uri": data["uri"], "valid": True}

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@ setup(
     version="0.1.0",
     license='MIT',
     packages=find_packages(),
+    entry_points={
+        'console_scripts': ['dacsspace=dacsspace.command_line:main'],
+    },
     zip_safe=False,
     classifiers=[
         'Programming Language :: Python :: 3',
@@ -22,6 +25,7 @@ setup(
     ],
     python_requires=">=3.7",
     install_requires=[
+        "jsonschema",
         "requests",
     ],
 )

--- a/tests/test_dacsspace.py
+++ b/tests/test_dacsspace.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from dacsspace.dacsspace import DACSspace
 
@@ -20,3 +21,31 @@ class TestDACSspace(TestCase):
             DACSspace("myfile")
         self.assertEqual(str(err.exception),
                          "File must have .csv extension")
+
+    @patch('dacsspace.client.ArchivesSpaceClient.__init__')
+    @patch('dacsspace.client.ArchivesSpaceClient.get_resources')
+    @patch('dacsspace.validator.Validator.__init__')
+    @patch('dacsspace.reporter.CSVReporter.__init__')
+    @patch('dacsspace.reporter.CSVReporter.write_report')
+    def test_args(self, mock_write_report, mock_reporter_init,
+                  mock_validator_init, mock_get_resources, mock_client_init):
+        """Asserts that arguments are passed to the correct methods."""
+        mock_reporter_init.return_value = None
+        mock_validator_init.return_value = None
+        mock_client_init.return_value = None
+        mock_get_resources.return_value = []
+        for csv_filepath, published_only, invalid_only, schema_identifier, schema_filepath in [
+                ('myfile.csv', False, True, 'single_level_required.json', None),
+                ('test.csv', True, True, None, 'filepath/to/schema.json'),
+                ('testfile.csv', False, False, 'single_level_required', None),
+                ('file.csv', True, False, 'rac.json', None)]:
+            DACSspace(csv_filepath).run(
+                published_only,
+                invalid_only,
+                schema_identifier,
+                schema_filepath)
+            mock_validator_init.assert_called_with(
+                schema_identifier, schema_filepath)
+            mock_reporter_init.assert_called_with(csv_filepath)
+            mock_get_resources.assert_called_with(published_only)
+            mock_write_report.assert_called_with([], invalid_only)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
 skip_install = True
 commands =
 	coverage run -m pytest -s
-	coverage report -m
+	coverage report -m --omit=tests/*
 
 [testenv:linting]
 basepython = python3


### PR DESCRIPTION
Adds a [entrypoint](https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html) script which allows DACSspace to be called via the command line. To try this out, from the root of the repository do:
```
pip install .
dacsspace test.csv
```

I've also done a bit of tidying up to tox and added an additional test to ensure that the arguments passed to the main `DACSspace` class are used correctly.

fixes #60 